### PR TITLE
Added refresh delay to full logoff

### DIFF
--- a/public/javascripts/socketutils.js
+++ b/public/javascripts/socketutils.js
@@ -1,6 +1,8 @@
 function addLogoffListener(socket) {
 
     socket.on("logoff", () => {
-        location.reload()
+        setTimeout(() => {
+            location.reload()
+        }, 1000);
     })
 }


### PR DESCRIPTION
This is to fix an issue where pages would reload just before cookies would update, causing the pages not to log out properly. Now, the page wait 1 second before refreshing, which should be more than enough delay for cookies to update.